### PR TITLE
Improve first time dev setup flow

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -28,11 +28,11 @@ ln -s docker-compose.dev.yml docker-compose.yml
 ```
 This environment maps the local repo into the container and will dynamically reload code changes.
 
-You will need to configure some hosts file entries, as the app uses DNS information to route to different events:
+If your OS doesn't resolve localhost domains automatically you may need to configure some hosts file entries, as the app uses DNS information to route to different events:
 ```shell
-echo 127.0.0.1 hunter2.local www.hunter2.local dev.hunter2.local >> /etc/hosts
+echo 127.0.0.1 hunter2.localhost www.hunter2.localhost dev.hunter2.localhost | sudo tee -a /etc/hosts
 ```
-`dev.hunter2.local` is the default event subdomain. If you are working with more events, add more names here.
+`dev.hunter2.localhost` is the default event subdomain. If you are working with more events, add more names here.
 
 The quickest way to build and launch is:
 

--- a/hunter2/management/commands/setupsite.py
+++ b/hunter2/management/commands/setupsite.py
@@ -14,6 +14,7 @@
 import sys
 
 import validators
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand, CommandError
 
@@ -25,7 +26,7 @@ class Command(BaseCommand):
     stealth_options = ('stdin', )
 
     DEFAULT_SITE_NAME   = "Hunter 2"
-    DEFAULT_SITE_DOMAIN = "hunter2.local"
+    DEFAULT_SITE_DOMAIN = settings.BASE_DOMAIN
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Use the value of BASE_DOMAIN for the default in setupsite so that default is hunter2.localhost not hunter2.local
Change the docs to indicate that hosts file entries will not always be required